### PR TITLE
Implement firewall unblocking logic

### DIFF
--- a/slips_files/core/evidence_handler.py
+++ b/slips_files/core/evidence_handler.py
@@ -81,9 +81,11 @@ class EvidenceHandler(ICore):
 
         self.c1 = self.db.subscribe("evidence_added")
         self.c2 = self.db.subscribe("new_blame")
+        self.c3 = self.db.subscribe("tw_closed")
         self.channels = {
             "evidence_added": self.c1,
             "new_blame": self.c2,
+            "tw_closed": self.c3,
         }
 
         # clear output/alerts.log
@@ -98,6 +100,8 @@ class EvidenceHandler(ICore):
         # this list will have our local and public ips when using -i
         self.our_ips = utils.get_own_ips()
         self.formatter = EvidenceFormatter(self.db)
+        # {profileid: tw_number_when_block_expires}
+        self.blocked_profiles: Dict[str, int] = {}
         # thats just a tmp value, this variable will be set and used when
         # the
         # module is stopping.
@@ -389,12 +393,24 @@ class EvidenceHandler(ICore):
         if self.popup_alerts:
             self.show_popup(alert)
 
-        is_blocked: bool = self.decide_blocking(alert.profile.ip)
-        if is_blocked:
-            self.db.mark_profile_and_timewindow_as_blocked(
-                str(alert.profile), str(alert.timewindow)
-            )
-        self.log_alert(alert, blocked=is_blocked)
+        profileid = str(alert.profile)
+        current_tw = alert.timewindow.number
+
+        unblock_tw = self.blocked_profiles.get(profileid)
+        should_block = unblock_tw is None or current_tw > unblock_tw
+
+        was_blocked = False
+        if should_block:
+            was_blocked = self.decide_blocking(alert.profile.ip)
+            if was_blocked:
+                self.db.mark_profile_and_timewindow_as_blocked(
+                    profileid, str(alert.timewindow)
+                )
+        # extend blocking if alert happens in the last blocked tw
+        if unblock_tw is None or current_tw >= (unblock_tw or -1):
+            self.blocked_profiles[profileid] = current_tw + 1
+
+        self.log_alert(alert, blocked=was_blocked)
 
     def decide_blocking(self, ip_to_block: str) -> bool:
         """
@@ -423,6 +439,19 @@ class EvidenceHandler(ICore):
         blocking_data = json.dumps(blocking_data)
         self.db.publish("new_blocking", blocking_data)
         return True
+
+    def handle_tw_closed(self, msg: Dict):
+        """Unblock profiles when their block period ends"""
+        profileid_tw = msg["data"].split("_")
+        profileid = f"{profileid_tw[0]}_{profileid_tw[1]}"
+        tw_number = int(profileid_tw[-1].replace("timewindow", ""))
+        unblock_tw = self.blocked_profiles.get(profileid)
+        if unblock_tw is None or tw_number != unblock_tw:
+            return
+        ip = profileid.split("_")[-1]
+        blocking_data = json.dumps({"ip": ip, "block": False})
+        self.db.publish("new_blocking", blocking_data)
+        self.blocked_profiles.pop(profileid, None)
 
     def increment_attack_counter(
         self,
@@ -629,3 +658,6 @@ class EvidenceHandler(ICore):
                 }
                 blocking_data = json.dumps(blocking_data)
                 self.db.publish("new_blocking", blocking_data)
+
+            if msg := self.get_msg("tw_closed"):
+                self.handle_tw_closed(msg)

--- a/tests/test_evidence_handler.py
+++ b/tests/test_evidence_handler.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 import pytest
 import os
+import json
 from unittest.mock import Mock, patch, call
 
 from slips_files.core.structures.alerts import Alert
@@ -156,7 +157,7 @@ def test_clean_file(output_dir, file_to_clean, file_exists):
         mock_exists.assert_called_once_with(expected_path)
         mock_open.assert_called_with(expected_path, "a")
 
-        assert result == mock_file
+    assert result == mock_file
 
 
 @pytest.mark.parametrize(
@@ -504,3 +505,59 @@ def test_log_alert(
     evidence_handler.add_alert_to_json_log_file.assert_called_once()
     assert flow_datetime in evidence_handler.add_to_log_file.call_args[0][0]
     assert str(twid) in evidence_handler.add_to_log_file.call_args[0][0]
+
+
+def create_alert(ip: str, tw_number: int):
+    return Alert(
+        profile=ProfileID(ip),
+        timewindow=TimeWindow(tw_number),
+        last_evidence=Mock(),
+        accumulated_threat_level=10,
+        last_flow_datetime="2024/01/01 10:00:00+0000",
+    )
+
+
+def test_unblock_profile_without_additional_alerts():
+    handler = ModuleFactory().create_evidence_handler_obj()
+    handler.decide_blocking = Mock(return_value=True)
+    handler.db.publish = Mock()
+    handler.db.mark_profile_and_timewindow_as_blocked = Mock()
+
+    alert = create_alert("192.168.1.5", 1)
+    handler.handle_new_alert(alert, {"e1": Mock(spec=Evidence)})
+
+    assert handler.blocked_profiles["profile_192.168.1.5"] == 2
+
+    handler.handle_tw_closed({"data": "profile_192.168.1.5_timewindow2"})
+
+    handler.db.publish.assert_any_call(
+        "new_blocking", json.dumps({"ip": "192.168.1.5", "block": False})
+    )
+    assert "profile_192.168.1.5" not in handler.blocked_profiles
+
+
+def test_extend_block_on_additional_alert():
+    handler = ModuleFactory().create_evidence_handler_obj()
+    handler.decide_blocking = Mock(return_value=True)
+    handler.db.publish = Mock()
+    handler.db.mark_profile_and_timewindow_as_blocked = Mock()
+
+    alert1 = create_alert("192.168.1.6", 1)
+    handler.handle_new_alert(alert1, {"e1": Mock(spec=Evidence)})
+
+    alert2 = create_alert("192.168.1.6", 2)
+    handler.handle_new_alert(alert2, {"e2": Mock(spec=Evidence)})
+
+    assert handler.blocked_profiles["profile_192.168.1.6"] == 3
+
+    handler.handle_tw_closed({"data": "profile_192.168.1.6_timewindow2"})
+    # Should not unblock yet
+    unblock_call = call(
+        "new_blocking", json.dumps({"ip": "192.168.1.6", "block": False})
+    )
+    assert unblock_call not in handler.db.publish.call_args_list
+
+    handler.handle_tw_closed({"data": "profile_192.168.1.6_timewindow3"})
+
+    assert unblock_call in handler.db.publish.call_args_list
+    assert "profile_192.168.1.6" not in handler.blocked_profiles


### PR DESCRIPTION
## Summary
- extend `EvidenceHandler` to subscribe to `tw_closed` channel
- track blocked profiles and unblock after desired timewindow
- update main loop to react to closed time windows
- add unit tests covering the new behaviour

## Testing
- `pip install pytest` *(fails: Cannot connect to proxy)*