### PR TITLE
Fix flows storage in IDMEF output

### DIFF
--- a/slips_files/common/idmefv2.py
+++ b/slips_files/common/idmefv2.py
@@ -72,9 +72,7 @@ class IDMEFv2:
     def print(self, *args, **kwargs):
         return self.printer.print(*args, **kwargs)
 
-    def convert_threat_level_to_idmefv2_severity(
-        self, threat_lvl: ThreatLevel
-    ) -> str:
+    def convert_threat_level_to_idmefv2_severity(self, threat_lvl: ThreatLevel) -> str:
         """
         converts slips threat level to a valid IDMEFv2 Severity value
         All threat levels have a corresponding sevirity except
@@ -86,9 +84,7 @@ class IDMEFv2:
         if threat_lvl.name == "CRITICAL":
             return IDMEFv2Severity.HIGH.value
 
-    def extract_role_type(
-        self, evidence: Evidence, role=None
-    ) -> Tuple[str, str]:
+    def extract_role_type(self, evidence: Evidence, role=None) -> Tuple[str, str]:
         """
         extracts the attacker or victim's ip/domain/url from the evidence
         and returns the ip/domain/url and its' type
@@ -118,9 +114,7 @@ class IDMEFv2:
         from the given evidence
         """
         return int(
-            evidence.description.replace(".", "")
-            .split("size:")[1]
-            .split("from")[0]
+            evidence.description.replace(".", "").split("size:")[1].split("from")[0]
         )
 
     def convert_to_idmef_alert(self, alert: Alert) -> Message:
@@ -184,12 +178,10 @@ class IDMEFv2:
         """
         try:
             now = datetime.now(utils.local_tz).isoformat("T")
-            iso_ts: str = utils.convert_format(
-                evidence.timestamp, "iso"
-            ).replace(" ", "T")
-            attacker, attacker_type = self.extract_role_type(
-                evidence, role="attacker"
+            iso_ts: str = utils.convert_format(evidence.timestamp, "iso").replace(
+                " ", "T"
             )
+            attacker, attacker_type = self.extract_role_type(evidence, role="attacker")
             severity: str = self.convert_threat_level_to_idmefv2_severity(
                 evidence.threat_level
             )
@@ -229,16 +221,12 @@ class IDMEFv2:
                 msg["Source"][0]["Note"].update({"AS": evidence.attacker.AS})
 
             if evidence.attacker.rDNS:
-                msg["Source"][0]["Note"].update(
-                    {"rDNS": evidence.attacker.rDNS}
-                )
+                msg["Source"][0]["Note"].update({"rDNS": evidence.attacker.rDNS})
             if evidence.attacker.SNI:
                 msg["Source"][0]["Note"].update({"SNI": evidence.attacker.SNI})
 
             if hasattr(evidence, "victim") and evidence.victim:
-                victim, victim_type = self.extract_role_type(
-                    evidence, role="victim"
-                )
+                victim, victim_type = self.extract_role_type(evidence, role="victim")
                 msg["Target"] = [
                     {
                         victim_type: victim,
@@ -246,9 +234,7 @@ class IDMEFv2:
                     }
                 ]
 
-                if evidence.dst_port and not self.is_icmp_code(
-                    evidence.dst_port
-                ):
+                if evidence.dst_port and not self.is_icmp_code(evidence.dst_port):
                     msg["Target"][0].update({"Port": [int(evidence.dst_port)]})
 
                 if evidence.victim.TI:
@@ -256,17 +242,12 @@ class IDMEFv2:
                 if evidence.victim.AS:
                     msg["Target"][0]["Note"].update({"AS": evidence.victim.AS})
                 if evidence.victim.rDNS:
-                    msg["Target"][0]["Note"].update(
-                        {"rDNS": evidence.victim.rDNS}
-                    )
+                    msg["Target"][0]["Note"].update({"rDNS": evidence.victim.rDNS})
                 if evidence.victim.SNI:
-                    msg["Target"][0]["Note"].update(
-                        {"SNI": evidence.victim.SNI}
-                    )
+                    msg["Target"][0]["Note"].update({"SNI": evidence.victim.SNI})
 
             if (
-                evidence.evidence_type
-                == EvidenceType.MALICIOUS_DOWNLOADED_FILE
+                evidence.evidence_type == EvidenceType.MALICIOUS_DOWNLOADED_FILE
                 and evidence.attacker.ioc_type == IoCType.MD5
             ):
                 msg["Attachment"] = [
@@ -277,11 +258,7 @@ class IDMEFv2:
                 ]
                 if "size" in evidence.description:
                     msg["Attachment"][0].update(
-                        {
-                            "Size": self.extract_file_size_from_evidence(
-                                evidence
-                            )
-                        }
+                        {"Size": self.extract_file_size_from_evidence(evidence)}
                     )
 
             if evidence.rel_id:
@@ -296,15 +273,13 @@ class IDMEFv2:
 
             if "Target" in msg:
                 if msg["Target"][0]["Note"]:
-                    msg["Target"][0]["Note"] = json.dumps(
-                        msg["Target"][0]["Note"]
-                    )
+                    msg["Target"][0]["Note"] = json.dumps(msg["Target"][0]["Note"])
                 else:
                     # remove the note field since its empty
                     del msg["Target"][0]["Note"]
 
-            # PS: The "Note" field is added by the evidencehandler before
-            # logging the evidence to alerts.json
+            # PS: Attachments containing flow information are added by the
+            # evidence handler before logging the evidence to alerts.json
             msg.validate()
             return msg
 

--- a/slips_files/core/evidence_handler.py
+++ b/slips_files/core/evidence_handler.py
@@ -166,18 +166,27 @@ class EvidenceHandler(ICore):
             return
 
         try:
+            flows_data = json.dumps(
+                {
+                    "uids": evidence.uid,
+                    "accumulated_threat_level": accumulated_threat_level,
+                    "threat_level": str(evidence.threat_level),
+                    "timewindow": evidence.timewindow.number,
+                }
+            )
+
             idmef_evidence.update(
                 {
-                    "Note": json.dumps(
+                    "Vector": [
                         {
-                            # this is all the uids of the flows that cause
-                            # this evidence
-                            "uids": evidence.uid,
-                            "accumulated_threat_level": accumulated_threat_level,
-                            "threat_level": str(evidence.threat_level),
-                            "timewindow": evidence.timewindow.number,
+                            "Attachment": [
+                                {
+                                    "Name": "flows",
+                                    "Data": flows_data,
+                                }
+                            ]
                         }
-                    )
+                    ]
                 }
             )
             json.dump(idmef_evidence, self.jsonfile)
@@ -266,14 +275,12 @@ class EvidenceHandler(ICore):
         filters and returns all the evidence for this profile in this TW
         returns the dict with filtered evidence
         """
-        tw_evidence: Dict[str, dict] = self.db.get_twid_evidence(
-            profileid, twid
-        )
+        tw_evidence: Dict[str, dict] = self.db.get_twid_evidence(profileid, twid)
         if not tw_evidence:
             return
 
-        past_evidence_ids: List[str] = (
-            self.get_evidence_that_were_part_of_a_past_alert(profileid, twid)
+        past_evidence_ids: List[str] = self.get_evidence_that_were_part_of_a_past_alert(
+            profileid, twid
         )
 
         filtered_evidence = {}
@@ -303,9 +310,7 @@ class EvidenceHandler(ICore):
 
         return filtered_evidence
 
-    def is_filtered_evidence(
-        self, evidence: Evidence, past_evidence_ids: List[str]
-    ):
+    def is_filtered_evidence(self, evidence: Evidence, past_evidence_ids: List[str]):
         """
         filters the following
         * evidence that were part of a past alert in this same profileid
@@ -342,9 +347,7 @@ class EvidenceHandler(ICore):
 
         # Compute the moving average of evidence
         evidence_threat_level: float = threat_level * confidence
-        self.print(
-            f"\t\tWeighted Threat Level: " f"{evidence_threat_level}", 3, 0
-        )
+        self.print(f"\t\tWeighted Threat Level: " f"{evidence_threat_level}", 3, 0)
         return evidence_threat_level
 
     def send_to_exporting_module(self, tw_evidence: Dict[str, Evidence]):
@@ -368,9 +371,7 @@ class EvidenceHandler(ICore):
         """
         custom_flows = "-im" in sys.argv or "--input-module" in sys.argv
         blocking_module_enabled = "-p" in sys.argv
-        return (
-            self.is_running_non_stop or custom_flows
-        ) and blocking_module_enabled
+        return (self.is_running_non_stop or custom_flows) and blocking_module_enabled
 
     def handle_new_alert(
         self, alert: Alert, evidence_causing_the_alert: Dict[str, Evidence]
@@ -509,15 +510,11 @@ class EvidenceHandler(ICore):
 
                 # convert time to local timezone
                 if self.is_running_non_stop:
-                    timestamp: datetime = utils.convert_to_local_timezone(
-                        timestamp
-                    )
+                    timestamp: datetime = utils.convert_to_local_timezone(timestamp)
                 flow_datetime = utils.convert_format(timestamp, "iso")
 
                 evidence: Evidence = (
-                    self.formatter.add_threat_level_to_evidence_description(
-                        evidence
-                    )
+                    self.formatter.add_threat_level_to_evidence_description(evidence)
                 )
 
                 evidence_to_log: str = self.formatter.get_evidence_to_log(
@@ -532,9 +529,7 @@ class EvidenceHandler(ICore):
                 )
 
                 past_evidence_ids: List[str] = (
-                    self.get_evidence_that_were_part_of_a_past_alert(
-                        profileid, twid
-                    )
+                    self.get_evidence_that_were_part_of_a_past_alert(profileid, twid)
                 )
                 # filtered evidence dont add to the acc threat level
                 if not self.is_filtered_evidence(evidence, past_evidence_ids):
@@ -568,16 +563,13 @@ class EvidenceHandler(ICore):
                 # So find out how many attacks corresponds
                 # to the width we are using
                 if (
-                    accumulated_threat_level
-                    >= self.detection_threshold_in_this_width
+                    accumulated_threat_level >= self.detection_threshold_in_this_width
                     and not profile_already_blocked
                 ):
                     tw_evidence: Dict[str, Evidence]
                     tw_evidence = self.get_evidence_for_tw(profileid, twid)
                     if tw_evidence:
-                        tw_start, tw_end = self.db.get_tw_limits(
-                            profileid, twid
-                        )
+                        tw_start, tw_end = self.db.get_tw_limits(profileid, twid)
                         evidence.timewindow.start_time = tw_start
                         evidence.timewindow.end_time = tw_end
 
@@ -595,9 +587,7 @@ class EvidenceHandler(ICore):
                 try:
                     data = json.loads(data)
                 except json.decoder.JSONDecodeError:
-                    self.print(
-                        "Error in the report received from p2ptrust module"
-                    )
+                    self.print("Error in the report received from p2ptrust module")
                     return
                 # The available values for the following variables are
                 # defined in go_director


### PR DESCRIPTION
## Summary
- move flow info from `Note` to `Attachment` when writing evidence to alerts.json
- update IDMEF helper comment about how flow data is added

## Testing
- `black slips_files/core/evidence_handler.py slips_files/common/idmefv2.py`
- `ruff check slips_files/core/evidence_handler.py slips_files/common/idmefv2.py`
