### PR TITLE
Clarify label source fields

### DIFF
--- a/config/slips.yaml
+++ b/config/slips.yaml
@@ -105,14 +105,14 @@ parameters:
   # deletePrevdb : false
   deletePrevdb: true
 
-  # Set the label for all the flows that are being read.
+  # Set the ground truth label for all the flows that are being read.
   # For now only normal and malware directly. No option for setting labels
-  # with a filter
+  # with a filter.
   # The purpose is to be used in the training of ML models and to output
   # flows with labels for other tools.
-  # label: malicious
-  # label: unknown
-  label: normal
+  # ground_truth_config_label: malicious
+  # ground_truth_config_label: unknown
+  ground_truth_config_label: normal
   # If Zeek files are rotated or not to avoid running out of disk.
   # Zeek rotation is enabled by default when using an interface,
   # which means Slips will delete all Zeek log files after 1 day

--- a/modules/flowmldetection/flowmldetection.py
+++ b/modules/flowmldetection/flowmldetection.py
@@ -87,7 +87,7 @@ class FlowMLDetection(IModule):
             # Separate
             y_flow = self.flows["label"]
             X_flow = self.flows.drop("label", axis=1)
-            X_flow = X_flow.drop("module_labels", axis=1)
+            X_flow = X_flow.drop("modules_predictions", axis=1)
 
             # Normalize this batch of data so far. This can get progressivle slow
             X_flow = self.scaler.fit_transform(X_flow)
@@ -241,7 +241,7 @@ class FlowMLDetection(IModule):
                         "sbytes": 25517,
                         "appproto": "ssl",
                         "label": "Malware",
-                        "module_labels": {
+                        "modules_predictions": {
                             "flowalerts-long-connection": "Malware"
                         },
                     }
@@ -261,7 +261,7 @@ class FlowMLDetection(IModule):
                         "sbytes": 100,
                         "appproto": "http",
                         "label": "Normal",
-                        "module_labels": {
+                        "modules_predictions": {
                             "flowalerts-long-connection": "Normal"
                         },
                     }
@@ -307,7 +307,7 @@ class FlowMLDetection(IModule):
             # clean the flow
             fields_to_drop = [
                 "label",
-                "module_labels",
+                "modules_predictions",
                 "uid",
                 "history",
                 "dir_",
@@ -316,8 +316,8 @@ class FlowMLDetection(IModule):
                 "endtime",
                 "bytes",
                 "flow_source",
-                "ground_truth_label",  # todo now we can use them
-                "detailed_ground_truth_label",
+                "ground_truth_logfile_label",  # todo now we can use them
+                "ground_truth_logfile_detailed_label",
             ]
             for field in fields_to_drop:
                 try:
@@ -435,7 +435,7 @@ class FlowMLDetection(IModule):
                     "state": msg["interpreted_state"],
                     "pkts": self.flow["spkts"] + self.flow["dpkts"],
                     "label": msg["label"],
-                    "module_labels": msg["module_labels"],
+                    "modules_predictions": msg["modules_predictions"],
                 }
             )
 

--- a/slips_files/common/parsers/config_parser.py
+++ b/slips_files/common/parsers/config_parser.py
@@ -602,8 +602,8 @@ class ConfigParser(object):
             "parameters", "store_zeek_files_in_the_output_dir", False
         )
 
-    def label(self):
-        return self.read_configuration("parameters", "label", "unknown")
+    def ground_truth_config_label(self):
+        return self.read_configuration("parameters", "ground_truth_config_label", "unknown")
 
     def get_UID(self):
         return int(self.read_configuration("Docker", "UID", 0))

--- a/slips_files/core/database/database_manager.py
+++ b/slips_files/core/database/database_manager.py
@@ -762,8 +762,8 @@ class DBManager:
     def add_profile(self, *args, **kwargs):
         return self.rdb.add_profile(*args, **kwargs)
 
-    def set_module_label_for_profile(self, *args, **kwargs):
-        return self.rdb.set_module_label_for_profile(*args, **kwargs)
+    def set_module_prediction_for_profile(self, *args, **kwargs):
+        return self.rdb.set_module_prediction_for_profile(*args, **kwargs)
 
     def check_tw_to_close(self, *args, **kwargs):
         return self.rdb.check_tw_to_close(*args, **kwargs)
@@ -808,8 +808,8 @@ class DBManager:
         # uid isn't in this twid or any of the previous ones
         return {uid: None}
 
-    def get_modules_labels_of_a_profile(self, *args, **kwargs):
-        return self.rdb.get_modules_labels_of_a_profile(*args, **kwargs)
+    def get_modules_predictions_of_a_profile(self, *args, **kwargs):
+        return self.rdb.get_modules_predictions_of_a_profile(*args, **kwargs)
 
     def add_timeline_line(self, *args, **kwargs):
         return self.rdb.add_timeline_line(*args, **kwargs)
@@ -878,12 +878,19 @@ class DBManager:
         """returns the raw flow as read from the log file"""
         return self.sqlite.get_flow(*args, **kwargs)
 
-    def add_flow(self, flow, profileid: str, twid: str, label="benign"):
+    def add_flow(
+        self, flow, profileid: str, twid: str, ground_truth_config_label="benign"
+    ):
         # stores it in the db
-        self.sqlite.add_flow(flow, profileid, twid, label=label)
+        self.sqlite.add_flow(
+            flow, profileid, twid, ground_truth_config_label=ground_truth_config_label
+        )
         # handles the channels and labels etc.
         return self.rdb.add_flow(
-            flow, profileid=profileid, twid=twid, label=label
+            flow,
+            profileid=profileid,
+            twid=twid,
+            ground_truth_config_label=ground_truth_config_label,
         )
 
     def get_slips_start_time(self):

--- a/slips_files/core/database/redis_db/profile_handler.py
+++ b/slips_files/core/database/redis_db/profile_handler.py
@@ -792,15 +792,17 @@ class ProfileHandler:
         flow,
         profileid="",
         twid="",
-        label="",
+        ground_truth_config_label="",
     ):
         """
         Function to add a flow by interpreting the data. The flow is added to
         the correct TW for this profile.
         The profileid is the main profile that this flow is related too.
         """
-        if label:
-            self.r.zincrby(self.constants.LABELS, 1, label)
+        if ground_truth_config_label:
+            self.r.zincrby(
+                self.constants.LABELS, 1, ground_truth_config_label
+            )
 
         to_send = {
             "profileid": profileid,
@@ -810,8 +812,8 @@ class ProfileHandler:
             "interpreted_state": self.get_final_state_from_flags(
                 flow.state, flow.pkts
             ),
-            "label": label,
-            "module_labels": {},
+            "ground_truth_config_label": ground_truth_config_label,
+            "modules_predictions": {},
         }
         to_send = json.dumps(to_send)
 
@@ -1492,16 +1494,18 @@ class ProfileHandler:
             self.print(type(inst), 0, 1)
             self.print(inst, 0, 1)
 
-    def set_module_label_for_profile(self, profileid, module, label):
+    def set_module_prediction_for_profile(
+        self, profileid, module, prediction
+    ):
         """
-        Set a module label for a profile.
-        A module label is a label set by a module, and not
+        Set a module prediction for a profile.
+        A module prediction is a label set by a module, and not
         a groundtruth label
         """
-        data = self.get_modules_labels_of_a_profile(profileid)
-        data[module] = label
+        data = self.get_modules_predictions_of_a_profile(profileid)
+        data[module] = prediction
         data = json.dumps(data)
-        self.r.hset(profileid, "modules_labels", data)
+        self.r.hset(profileid, "modules_predictions", data)
 
     def check_tw_to_close(self, close_all=False):
         """
@@ -1699,11 +1703,9 @@ class ProfileHandler:
             )
             self.print(traceback.format_exc(), 0, 1)
 
-    def get_modules_labels_of_a_profile(self, profileid):
-        """
-        Get labels set by modules in the profile.
-        """
-        data = self.r.hget(profileid, "modules_labels")
+    def get_modules_predictions_of_a_profile(self, profileid):
+        """Get predictions set by modules in the profile."""
+        data = self.r.hget(profileid, "modules_predictions")
         data = json.loads(data) if data else {}
         return data
 

--- a/slips_files/core/database/sqlite_db/database.py
+++ b/slips_files/core/database/sqlite_db/database.py
@@ -239,14 +239,16 @@ class SQLiteDB:
         res = res[0][1] if res else {}
         return {uid: res}
 
-    def add_flow(self, flow, profileid: str, twid: str, label="benign"):
+    def add_flow(
+        self, flow, profileid: str, twid: str, ground_truth_config_label="benign"
+    ):
         if hasattr(flow, "aid"):
             parameters = (
                 profileid,
                 twid,
                 flow.uid,
                 json.dumps(asdict(flow)),
-                label,
+                ground_truth_config_label,
                 flow.aid,
             )
             self.execute(
@@ -260,7 +262,7 @@ class SQLiteDB:
                 twid,
                 flow.uid,
                 json.dumps(asdict(flow)),
-                label,
+                ground_truth_config_label,
             )
 
             self.execute(
@@ -286,13 +288,15 @@ class SQLiteDB:
         # flows += self.get_count('altflows', condition=condition)
         return flows
 
-    def add_altflow(self, flow, profileid: str, twid: str, label="benign"):
+    def add_altflow(
+        self, flow, profileid: str, twid: str, ground_truth_config_label="benign"
+    ):
         parameters = (
             profileid,
             twid,
             flow.uid,
             json.dumps(asdict(flow)),
-            label,
+            ground_truth_config_label,
             flow.type_,
         )
         self.execute(

--- a/slips_files/core/flows/zeek.py
+++ b/slips_files/core/flows/zeek.py
@@ -42,8 +42,8 @@ class Conn:
 
     # this is for when you give flows labeled by the netflow labeler
     # https://github.com/stratosphereips/netflowlabeler
-    ground_truth_label: str = ""
-    detailed_ground_truth_label: str = ""
+    ground_truth_logfile_label: str = ""
+    ground_truth_logfile_detailed_label: str = ""
 
     type_: str = "conn"
     dir_: str = "->"
@@ -80,8 +80,8 @@ class DNS:
 
     answers: List[str]
     TTLs: str
-    ground_truth_label: str = ""
-    detailed_ground_truth_label: str = ""
+    ground_truth_logfile_label: str = ""
+    ground_truth_logfile_detailed_label: str = ""
 
     type_: str = "dns"
 
@@ -116,8 +116,8 @@ class HTTP:
     resp_mime_types: str
     resp_fuids: str
 
-    ground_truth_label: str = ""
-    detailed_ground_truth_label: str = ""
+    ground_truth_logfile_label: str = ""
+    ground_truth_logfile_detailed_label: str = ""
 
     type_: str = "http"
 
@@ -154,8 +154,8 @@ class SSL:
     ja3s: str
     is_DoH: str
 
-    ground_truth_label: str = ""
-    detailed_ground_truth_label: str = ""
+    ground_truth_logfile_label: str = ""
+    ground_truth_logfile_detailed_label: str = ""
 
     type_: str = "ssl"
 
@@ -182,8 +182,8 @@ class SSH:
     host_key_alg: str
     host_key: str
 
-    ground_truth_label: str = ""
-    detailed_ground_truth_label: str = ""
+    ground_truth_logfile_label: str = ""
+    ground_truth_logfile_detailed_label: str = ""
 
     type_: str = "ssh"
 
@@ -199,8 +199,8 @@ class DHCP:
     smac: str  # this is the client mac
     requested_addr: str
 
-    ground_truth_label: str = ""
-    detailed_ground_truth_label: str = ""
+    ground_truth_logfile_label: str = ""
+    ground_truth_logfile_detailed_label: str = ""
 
     type_: str = "dhcp"
 
@@ -224,8 +224,8 @@ class FTP:
 
     used_port: int
 
-    ground_truth_label: str = ""
-    detailed_ground_truth_label: str = ""
+    ground_truth_logfile_label: str = ""
+    ground_truth_logfile_detailed_label: str = ""
 
     type_: str = "ftp"
 
@@ -239,8 +239,8 @@ class SMTP:
 
     last_reply: str
 
-    ground_truth_label: str = ""
-    detailed_ground_truth_label: str = ""
+    ground_truth_logfile_label: str = ""
+    ground_truth_logfile_detailed_label: str = ""
 
     type_: str = "smtp"
 
@@ -258,8 +258,8 @@ class Tunnel:
     tunnel_type: str
     action: str
 
-    ground_truth_label: str = ""
-    detailed_ground_truth_label: str = ""
+    ground_truth_logfile_label: str = ""
+    ground_truth_logfile_detailed_label: str = ""
 
     type_: str = "tunnel"
 
@@ -282,8 +282,8 @@ class Notice:
     # TODO srsly what is this?
     dst: str
 
-    ground_truth_label: str = ""
-    detailed_ground_truth_label: str = ""
+    ground_truth_logfile_label: str = ""
+    ground_truth_logfile_detailed_label: str = ""
 
     # every evidence needs a uid, notice.log flows dont have one by
     # default, slips adds one to them to be able to deal with it.
@@ -328,8 +328,8 @@ class Files:
     tx_hosts: List[str]
     rx_hosts: List[str]
 
-    ground_truth_label: str = ""
-    detailed_ground_truth_label: str = ""
+    ground_truth_logfile_label: str = ""
+    ground_truth_logfile_detailed_label: str = ""
 
     type_: str = "files"
 
@@ -376,8 +376,8 @@ class ARP:
     dpkts: str = ""
     appproto: str = ""
 
-    ground_truth_label: str = ""
-    detailed_ground_truth_label: str = ""
+    ground_truth_logfile_label: str = ""
+    ground_truth_logfile_detailed_label: str = ""
 
     type_: str = "arp"
 
@@ -396,8 +396,8 @@ class Software:
     version_minor: str
     # software log lines dont have daddr
     daddr: str = ""
-    ground_truth_label: str = ""
-    detailed_ground_truth_label: str = ""
+    ground_truth_logfile_label: str = ""
+    ground_truth_logfile_detailed_label: str = ""
 
     type_: str = "software"
 

--- a/slips_files/core/helpers/flow_handler.py
+++ b/slips_files/core/helpers/flow_handler.py
@@ -129,7 +129,12 @@ class FlowHandler:
         port_type = "Src"
         self.db.add_port(self.profileid, self.twid, self.flow, role, port_type)
         # store the original flow as benign in sqlite
-        self.db.add_flow(self.flow, self.profileid, self.twid, "benign")
+        self.db.add_flow(
+            self.flow,
+            self.profileid,
+            self.twid,
+            ground_truth_config_label="benign",
+        )
 
         self.db.add_mac_addr_to_profile(self.profileid, self.flow.smac)
 

--- a/slips_files/core/input_profilers/zeek_to_slips_maps.py
+++ b/slips_files/core/input_profilers/zeek_to_slips_maps.py
@@ -14,8 +14,8 @@ conn_fields_to_slips_fields_map = {
     "history": "history",
     "orig_pkts": "spkts",
     "resp_pkts": "dpkts",
-    "label": "ground_truth_label",
-    "detailedlabel": "detailed_ground_truth_label",
+    "label": "ground_truth_logfile_label",
+    "detailedlabel": "ground_truth_logfile_detailed_label",
 }
 
 dns_fields_to_slips_fields_map = {
@@ -32,8 +32,8 @@ dns_fields_to_slips_fields_map = {
     "rcode_name": "rcode_name",
     "answers": "answers",
     "TTLs": "TTLs",
-    "label": "ground_truth_label",
-    "detailedlabel": "detailed_ground_truth_label",
+    "label": "ground_truth_logfile_label",
+    "detailedlabel": "ground_truth_logfile_detailed_label",
 }
 
 http_fields_to_slips_fields_map = {
@@ -55,8 +55,8 @@ http_fields_to_slips_fields_map = {
     "status_msg": "status_msg",
     "resp_mime_types": "resp_mime_types",
     "resp_fuids": "resp_fuids",
-    "label": "ground_truth_label",
-    "detailedlabel": "detailed_ground_truth_label",
+    "label": "ground_truth_logfile_label",
+    "detailedlabel": "ground_truth_logfile_detailed_label",
 }
 
 ssl_fields_to_slips_fields_map = {
@@ -78,8 +78,8 @@ ssl_fields_to_slips_fields_map = {
     "curve": "curve",
     "ja3": "ja3",
     "ja3s": "ja3s",
-    "label": "ground_truth_label",
-    "detailedlabel": "detailed_ground_truth_label",
+    "label": "ground_truth_logfile_label",
+    "detailedlabel": "ground_truth_logfile_detailed_label",
 }
 
 ssh_fields_to_slips_fields_map = {
@@ -97,8 +97,8 @@ ssh_fields_to_slips_fields_map = {
     "kex_alg": "kex_alg",
     "host_key_alg": "host_key_alg",
     "host_key": "host_key",
-    "label": "ground_truth_label",
-    "detailedlabel": "detailed_ground_truth_label",
+    "label": "ground_truth_logfile_label",
+    "detailedlabel": "ground_truth_logfile_detailed_label",
 }
 
 dhcp_fields_to_slips_fields_map = {
@@ -109,8 +109,8 @@ dhcp_fields_to_slips_fields_map = {
     "mac": "smac",
     "host_name": "host_name",
     "requested_addr": "requested_addr",
-    "label": "ground_truth_label",
-    "detailedlabel": "detailed_ground_truth_label",
+    "label": "ground_truth_logfile_label",
+    "detailedlabel": "ground_truth_logfile_detailed_label",
 }
 
 ftp_fields_to_slips_fields_map = {
@@ -121,8 +121,8 @@ ftp_fields_to_slips_fields_map = {
     "id.resp_h": "daddr",
     "id.resp_p": "dport",
     "data_channel.resp_p": "used_port",
-    "label": "ground_truth_label",
-    "detailedlabel": "detailed_ground_truth_label",
+    "label": "ground_truth_logfile_label",
+    "detailedlabel": "ground_truth_logfile_detailed_label",
 }
 
 smtp_fields_to_slips_fields_map = {
@@ -133,8 +133,8 @@ smtp_fields_to_slips_fields_map = {
     "id.resp_h": "daddr",
     "id.resp_p": "dport",
     "last_reply": "last_reply",
-    "label": "ground_truth_label",
-    "detailedlabel": "detailed_ground_truth_label",
+    "label": "ground_truth_logfile_label",
+    "detailedlabel": "ground_truth_logfile_detailed_label",
 }
 
 tunnel_fields_to_slips_fields_map = {
@@ -146,8 +146,8 @@ tunnel_fields_to_slips_fields_map = {
     "id.resp_p": "dport",
     "tunnel_type": "tunnel_type",
     "action": "action",
-    "label": "ground_truth_label",
-    "detailedlabel": "detailed_ground_truth_label",
+    "label": "ground_truth_logfile_label",
+    "detailedlabel": "ground_truth_logfile_detailed_label",
 }
 
 notice_fields_to_slips_fields_map = {
@@ -162,8 +162,8 @@ notice_fields_to_slips_fields_map = {
     "src": "scanning_ip",
     "dst": "dst",
     "p": "scanned_port",
-    "label": "ground_truth_label",
-    "detailedlabel": "detailed_ground_truth_label",
+    "label": "ground_truth_logfile_label",
+    "detailedlabel": "ground_truth_logfile_detailed_label",
 }
 
 files_fields_to_slips_fields_map = {
@@ -176,8 +176,8 @@ files_fields_to_slips_fields_map = {
     "md5": "md5",
     "sha1": "sha1",
     "total_bytes": "size",
-    "label": "ground_truth_label",
-    "detailedlabel": "detailed_ground_truth_label",
+    "label": "ground_truth_logfile_label",
+    "detailedlabel": "ground_truth_logfile_detailed_label",
 }
 
 arp_fields_to_slips_fields_map = {
@@ -190,8 +190,8 @@ arp_fields_to_slips_fields_map = {
     "src_mac": "smac",
     "dst_mac": "dmac",
     "operation": "operation",
-    "label": "ground_truth_label",
-    "detailedlabel": "detailed_ground_truth_label",
+    "label": "ground_truth_logfile_label",
+    "detailedlabel": "ground_truth_logfile_detailed_label",
 }
 
 software_fields_to_slips_fields_map = {
@@ -202,8 +202,8 @@ software_fields_to_slips_fields_map = {
     "version.major": "version_major",
     "version.minor": "version_minor",
     "unparsed_version": "unparsed_version",
-    "label": "ground_truth_label",
-    "detailedlabel": "detailed_ground_truth_label",
+    "label": "ground_truth_logfile_label",
+    "detailedlabel": "ground_truth_logfile_detailed_label",
 }
 
 weird_fields_to_slips_fields_map = {

--- a/slips_files/core/profiler.py
+++ b/slips_files/core/profiler.py
@@ -119,7 +119,7 @@ class Profiler(ICore, IObservable):
         self.local_whitelist_path = conf.local_whitelist_path()
         self.timeformat = conf.ts_format()
         self.analysis_direction = conf.analysis_direction()
-        self.label = conf.label()
+        self.ground_truth_config_label = conf.ground_truth_config_label()
         self.width = conf.get_tw_width_as_float()
         self.client_ips: List[
             Union[IPv4Network, IPv6Network, IPv4Address, IPv6Address]
@@ -377,7 +377,7 @@ class Profiler(ICore, IObservable):
             flow,
             profileid=profileid,
             twid=twid,
-            label=self.label,
+            ground_truth_config_label=self.ground_truth_config_label,
         )
         self.db.mark_profile_tw_as_modified(profileid, twid, "")
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -150,13 +150,13 @@ def test_subscribe():
     assert isinstance(db.subscribe("tw_modified"), redis.client.PubSub)
 
 
-def test_profile_moddule_labels():
-    """tests set and get_profile_module_label"""
+def test_profile_module_predictions():
+    """tests set and get_profile_module_prediction"""
     db = ModuleFactory().create_db_manager_obj(6387, flush_db=True)
     module_label = "malicious"
     module_name = "test"
-    db.set_module_label_for_profile(profileid, module_name, module_label)
-    labels = db.get_modules_labels_of_a_profile(profileid)
+    db.set_module_prediction_for_profile(profileid, module_name, module_label)
+    labels = db.get_modules_predictions_of_a_profile(profileid)
     assert "test" in labels
     assert labels["test"] == "malicious"
 

--- a/tests/test_profile_handler.py
+++ b/tests/test_profile_handler.py
@@ -1038,7 +1038,7 @@ def test_get_user_agent_from_profile(
 
 
 @pytest.mark.parametrize(
-    "get_profile_modules_labels_return_value, " "module, label, expected_data",
+    "get_profile_modules_predictions_return_value, " "module, prediction, expected_data",
     [
         # Testcase 1: No existing module labels
         ({}, "test_module", "test_label", {"test_module": "test_label"}),
@@ -1059,22 +1059,22 @@ def test_get_user_agent_from_profile(
         ),
     ],
 )
-def test_set_profile_module_label(
-    get_profile_modules_labels_return_value, module, label, expected_data
+def test_set_profile_module_prediction(
+    get_profile_modules_predictions_return_value, module, prediction, expected_data
 ):
     handler = ModuleFactory().create_profile_handler_obj()
 
-    handler.get_modules_labels_of_a_profile = MagicMock(
-        return_value=get_profile_modules_labels_return_value
+    handler.get_modules_predictions_of_a_profile = MagicMock(
+        return_value=get_profile_modules_predictions_return_value
     )
 
     profileid = "profile_1"
 
-    handler.set_module_label_for_profile(profileid, module, label)
+    handler.set_module_prediction_for_profile(profileid, module, prediction)
 
     expected_data_str = json.dumps(expected_data)
     handler.r.hset.assert_called_once_with(
-        profileid, "modules_labels", expected_data_str
+        profileid, "modules_predictions", expected_data_str
     )
 
 
@@ -1661,15 +1661,15 @@ def test_add_existing_user_agent_to_profile():
         (None, {}),
     ],
 )
-def test_get_profile_modules_labels(hget_return_value, expected_data):
+def test_get_profile_modules_predictions(hget_return_value, expected_data):
     handler = ModuleFactory().create_profile_handler_obj()
 
     profileid = "profile_1"
 
     handler.r.hget.return_value = hget_return_value
 
-    data = handler.get_modules_labels_of_a_profile(profileid)
-    handler.r.hget.assert_called_once_with(profileid, "modules_labels")
+    data = handler.get_modules_predictions_of_a_profile(profileid)
+    handler.r.hget.assert_called_once_with(profileid, "modules_predictions")
     assert data == expected_data
 
 

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -481,7 +481,7 @@ def test_read_configuration(
     mock_conf.local_whitelist_path.return_value = "path/to/whitelist"
     mock_conf.ts_format.return_value = "unixtimestamp"
     mock_conf.analysis_direction.return_value = "all"
-    mock_conf.label.return_value = "malicious"
+    mock_conf.ground_truth_config_label.return_value = "malicious"
     mock_conf.get_tw_width_as_float.return_value = 1.0
     mock_conf.client_ips.return_value = ["192.168.1.1", "10.0.0.1"]
 
@@ -490,7 +490,7 @@ def test_read_configuration(
     assert profiler.local_whitelist_path == "path/to/whitelist"
     assert profiler.timeformat == "unixtimestamp"
     assert profiler.analysis_direction == "all"
-    assert profiler.label == "malicious"
+    assert profiler.ground_truth_config_label == "malicious"
     assert profiler.width == 1.0
     assert profiler.client_ips == ["192.168.1.1", "10.0.0.1"]
 


### PR DESCRIPTION
## Summary
- rename config `label` to `ground_truth_config_label`
- rename flow and mapping fields for log labels
- rename module label helpers to use `modules_predictions`
- propagate new parameter names through DB and helpers
- update tests accordingly

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*